### PR TITLE
chore(bower): use unminified source

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Serhioromano <serg4172@mail.ru>"
   ],
   "description": "AWS S3 uploader",
-  "main": "angular-s3.min.js",
+  "main": "angular-s3.js",
   "moduleType": [
     "globals"
   ],


### PR DESCRIPTION
The [bower spec](https://github.com/bower/spec/blob/12cfef122755ce12f1ec920c53260f516a52d50e/json.md#main) for the `main` property mentions:

> Do not include minified files.

Currently, Bower throws a warning "`main` should not include minifed files" (or
words to that degree) when running `bower install`. This fixes that.
