### PR TITLE
fix: don't set default ACL

### DIFF
--- a/angular-s3.js
+++ b/angular-s3.js
@@ -175,12 +175,15 @@
 
 				var fd = new FormData();
 				fd.append('key', key);
-				fd.append('acl', scope.options.acl || 'public-read');
 				fd.append('Content-Type', file.type);
 				fd.append('AWSAccessKeyId', scope.options.policy.key);
 				fd.append('policy', scope.options.policy.policy);
 				fd.append('signature', scope.options.policy.signature);
 				fd.append("file", file);
+
+				if (scope.options.acl) {
+					fd.append('acl', scope.options.acl);
+				}
 
 				var xhr = new XMLHttpRequest();
 				xhr.upload.addEventListener("progress", uploadProgress, false);


### PR DESCRIPTION
Better to be explicit about this. I left this option undefined and was receiving
unexpected "AccessDenied" errors from S3 because I hadn't granted the
`S3:PutObjectAcl` permission.

I didn't realise angular-aws-s3-upload imposed a default.

If an ACL isn't set, the bucket's policy is used.
