### PR TITLE
feat: expose on_upload_state via handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ totalsize | num | Number in bytes maximum allowed size for list of files.
 region | string | AWS S3 region: 'us-east-1'.
 limit | num | Number of files to uplaod. 0 is unlimited.
 on_success | function | callback on success file upload.
+on_upload_state_change | function | Callback passed `true` when uploading starts and `false` when it stops.
 replace | boolean | Only works with `limit` set to 1. In this case on new selection it will simply override existing file.
 policy | object | AWS policy object. Explained later.
 policyUrl | string | URL to get policy object.

--- a/angular-s3.js
+++ b/angular-s3.js
@@ -97,6 +97,9 @@
 
 				scope.upload = function() {
 					scope.start_upload_state = true;
+					if(angular.isFunction(scope.options.on_upload_state_change)) {
+						scope.options.on_upload_state_change(true);
+					}
 
 					ngModel.$setValidity('policy_content', true);
 					ngModel.$setValidity('policy_get', true);
@@ -255,13 +258,15 @@
 							delete file.lastModified;
 
 							scope.start_upload_state = false;
+							if(angular.isFunction(scope.options.on_upload_state_change)) {
+								scope.options.on_upload_state_change(false);
+							}
 
 							if(success) {
 								defer.resolve(file);
 							} else {
 								defer.reject(xhr);
 							}
-							scope.start_upload_state = false;
 						});
 					}, 0);
 				}


### PR DESCRIPTION
Useful for things like progress spinners. Note, avoided using an EventEmitter
for easier integration with `.component`.
